### PR TITLE
Add TouIST Server Integration, Multi-Model Support, and Enhanced Logging for Epistemic Reasoner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 .idea/
 /desc_cache.json
 /cache/
+logs/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The agents using this reasoner can be found at: https://github.com/Ethavanol/epi
 ## Prerequisites
 Node Version: 16 (Current, found here: https://nodejs.org/en/download/current/).
 
-The TouIST Service and the TouIST tool. For this, refer to here :
+This API will call another Service written in Python and using the TouIST command line tool.
+The TouIST Service and the TouIST tool need to be installed. For this, refer to here :
 
 ## Setting up the application
 ### 1. Clone the repository

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Epistemic Reasoner API (Express/Node.js Server)
 This is a fork of [Michael Vezina Epistemic Reasonner](https://github.com/MikeVezina/epistemic-reasoner). This server provides a simple API for creating, updating, and reasoning about Explicit Epistemic models. 
 
-## Epistemic Agents
+## Epistemic Jason
 The Jason BDI extension using this reasoner can be found at: https://github.com/Ethavanol/epistemic-jason
 
 # Getting Started

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a fork of [Michael Vezina Epistemic Reasonner](https://github.com/MikeVezina/epistemic-reasoner). This server provides a simple API for creating, updating, and reasoning about Explicit Epistemic models. 
 
 ## Epistemic Agents
-The agents using this reasoner can be found at: https://github.com/Ethavanol/epistemic-agents
+The Jason BDI extension using this reasoner can be found at: https://github.com/Ethavanol/epistemic-jason
 
 # Getting Started
 ## Prerequisites
@@ -27,3 +27,7 @@ npm install
 ```
 npm start
 ```
+
+## Configuration and services
+
+You will be able to find logs of agents in a logs folder that will be created at runtime.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
-# Epistemic Reasoning as a Service
-Deployed at (there is no front-end): https://epistemic-reasoner.herokuapp.com/
-
 ## Epistemic Reasoner API (Express/Node.js Server)
 This is a fork of [hintikkasworld](https://gitlab.inria.fr/fschwarz/hintikkasworld) that has been stripped of anything other than the explicit models and barebones reasoner, and exposes the functionality via a REST API. This server provides a simple API for creating, updating, and reasoning about Explicit Epistemic models. 
 
 ## Epistemic Agents
-The agents using this reasoner can be found at: https://github.com/MikeVezina/epistemic-agents
+The agents using this reasoner can be found at: https://github.com/Ethavanol/epistemic-agents
 
 # Getting Started
 ## Prerequisites
-Node Version: 13 (Current, found here: https://nodejs.org/en/download/current/)
+Node Version: 16 (Current, found here: https://nodejs.org/en/download/current/)
+The TouIST Service and the TouIST tool. For this, refer to here :
 
 ## Setting up the application
 ### 1. Clone the repository
 ```
-git clone https://github.com/MikeVezina/epistemic-reasoner.git
+git clone https://github.com/Ethavanol/epistemic-reasoner.git
 cd epistemic-reasoner
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The agents using this reasoner can be found at: https://github.com/Ethavanol/epi
 Node Version: 16 (Current, found here: https://nodejs.org/en/download/current/).
 
 This API will call another Service written in Python and using the TouIST command line tool.
-The TouIST Service and the TouIST tool need to be installed. For this, refer to here :
+The TouIST Service and the TouIST tool need to be installed. For this, refer to here : https://github.com/Ethavanol/touist-service
 
 ## Setting up the application
 ### 1. Clone the repository

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Epistemic Reasoner API (Express/Node.js Server)
-This is a fork of [hintikkasworld](https://gitlab.inria.fr/fschwarz/hintikkasworld) that has been stripped of anything other than the explicit models and barebones reasoner, and exposes the functionality via a REST API. This server provides a simple API for creating, updating, and reasoning about Explicit Epistemic models. 
+This is a fork of [Michael Vezina Epistemic Reasonner](https://github.com/MikeVezina/epistemic-reasoner). This server provides a simple API for creating, updating, and reasoning about Explicit Epistemic models. 
 
 ## Epistemic Agents
 The agents using this reasoner can be found at: https://github.com/Ethavanol/epistemic-agents

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ The agents using this reasoner can be found at: https://github.com/Ethavanol/epi
 
 # Getting Started
 ## Prerequisites
-Node Version: 16 (Current, found here: https://nodejs.org/en/download/current/)
+Node Version: 16 (Current, found here: https://nodejs.org/en/download/current/).
+
 The TouIST Service and the TouIST tool. For this, refer to here :
 
 ## Setting up the application

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ npm start
 
 ## Configuration and services
 
-You will be able to find logs of agents in a logs folder that will be created at runtime.
+You will be able to find logs of agents in a logs/ folder that will be created at runtime.

--- a/package.json
+++ b/package.json
@@ -11,21 +11,23 @@
     "@types/express": "^4.17.3",
     "@types/jest": "^25.1.4",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^13.9.1",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "extend": "^3.0.2",
-    "jest": "^25.1.0",
     "n-readlines": "^1.0.1",
     "source-map-support": "^0.5.19",
-    "ts-jest": "^25.2.1",
     "ts-node": "^8.6.2",
+    "tslib": "^2.8.1",
     "tslint": "^6.1.0",
-    "typescript": "^3.8.3"
+    "ws": "^8.18.1"
   },
   "devDependencies": {
+    "@types/node": "^22.13.10",
     "fetch": "^1.1.0",
+    "jest": "^29.7.0",
     "node-fetch": "^2.6.1",
-    "request": "^2.88.2"
+    "request": "^2.88.2",
+    "ts-jest": "^29.2.6",
+    "typescript": "^5.8.2"
   }
 }

--- a/src/app/ApiRouter.ts
+++ b/src/app/ApiRouter.ts
@@ -12,7 +12,7 @@ import {
     YFormula
 } from './modules/core/models/formula/formula';
 import {ExplicitEpistemicModel} from './modules/core/models/epistemicmodel/explicit-epistemic-model';
-import fs from 'fs';
+import fs, { WriteStream } from 'fs';
 import {JasonAgentEnvironment} from './models/JasonAgentEnvironment';
 import {JasonAgentDescription} from './models/JasonAgentDescription';
 import {AgentExplicitEpistemicModel} from './modules/core/models/epistemicmodel/agent-explicit-epistemic-model';
@@ -29,8 +29,38 @@ import {AgentEventModel} from './modules/core/models/eventmodel/agent-event-mode
 
 import Readlines from 'n-readlines';
 import * as process from 'process';
+import * as path from 'path';
+
+
 
 let SEPARATE_WORLDS_AGENTS : Boolean;
+
+function getTimestampedLogDir(baseDir: string = 'logs'): string {
+    const now = new Date();
+    const timestamp = now.toISOString().replace(/:/g, '-').replace(/\..+/, '');
+    const logDir = path.join(baseDir, timestamp);
+
+    if (!fs.existsSync(logDir)) {
+        fs.mkdirSync(logDir, { recursive: true });
+    }
+
+    return logDir;
+}
+
+function getAgentLogFile(agentName: string, logDir: string): fs.WriteStream {
+    const filePath = path.join(logDir, `${agentName}.log`);
+    return fs.createWriteStream(filePath, { flags: 'a' });  // 'a' pour append
+}
+
+
+function log(message: string, agentLog?: fs.WriteStream) {
+    if (agentLog) {
+        agentLog.write(message + '\n');
+    }
+}
+
+
+
 
 function createAcesAndEightsModel(): object {
     return {
@@ -299,6 +329,8 @@ export class ApiRouter {
         // constraintsToModels((name) => name.indexOf('_DISABLE') >= 0);
         constraintsToModels((name) => name.indexOf('_DISABLE') >= 0);
 
+        let logDir : string;
+
 
         const file = 'desc_cache.json';
         let descCache = {};
@@ -357,8 +389,11 @@ export class ApiRouter {
          * Output: { result: boolean }
          */
         app.post('/api/single-evaluate', async function(req, res) {
+            let modelID:string;
+            let agentLog : WriteStream;
             if(SEPARATE_WORLDS_AGENTS){
                 let modelID = req.body.id;
+                agentLog = getAgentLogFile(modelID, logDir);
                 if(modelID === undefined){
                     console.log('No id for the world given');
                     return res.send({
@@ -391,6 +426,11 @@ export class ApiRouter {
             let evalStart = Date.now();
             let result = currentModel.checkSync(parsedForm);
             let delta = Date.now() - evalStart;
+
+            if(SEPARATE_WORLDS_AGENTS) {
+                agentLog.write('***SINGLE-EVALUATE*** \n');
+                agentLog.write(`FORMULA : ${parsedForm.prettyPrint()} --> ${result}  \n`);
+            }
 
             console.log('Single formula took ' + (Date.now() - start) + '(total), or eval time: ' + delta);
 
@@ -434,6 +474,8 @@ export class ApiRouter {
         });
 
         async function createModelRequest(req, res: express.Response) {
+            logDir = getTimestampedLogDir();
+            console.log('LOG DIR : ', logDir);
             let data = req.body;
             if (!data || (!data.constraints && !data.locations_model)) {
 
@@ -442,9 +484,12 @@ export class ApiRouter {
             }
 
             SEPARATE_WORLDS_AGENTS = data.separateWorlds;
-            let modelID : String;
+            let agentLog : WriteStream;
+            let modelID : string;
             if(SEPARATE_WORLDS_AGENTS){
                 modelID = data.id;
+                agentLog = getAgentLogFile(modelID, logDir);
+                agentLog.write(`Agent ${modelID} started\n`);
                 if(modelID === undefined){
                     console.log('No id for the world given');
                     return res.send({
@@ -486,24 +531,23 @@ export class ApiRouter {
 
                     // Create model parse end time
                     let modelParseEnd = Date.now();
-
-                    console.log('');
-                    console.log('Model Metrics:');
-                    console.log('------- -------');
-                    // console.log('Cached: ' + isCached);
-                    // console.log('Generation Time (ms): ' + (genEnd - start));
-                    // console.log('Model Creation Time (ms): ' + (modelParseEnd - genEnd));
-                    console.log('Total Time (ms): ' + (modelParseEnd - start));
-                    console.log('------- -------');
-                    console.log('Constraints: ' + data.locations_model);
-                    console.log('Worlds: ' + currentModel.getNumberWorlds());
-                    console.log('Atomic Propositions: ' + currentModel.getAtomicPropositions().size);
-                    console.log('Edges/Simulated: ' + currentModel.getNumberEdges() + ' / ' + currentModel.getNumberFalseEdges());
-                    console.log('Pointed: ' + currentModel.getPointedWorldID());
-                    console.log('======= =======');
+                    
+                    let logText = '';
+                    logText += `CURRENT MODEL :\n${currentModel.toString()} \n`;
+                    logText += 'Model Metrics:\n';
+                    logText += '------- -------\n';
+                    logText += `Total Time (ms): ${modelParseEnd - start}\n`;
+                    logText += `Constraints: ${data.locations_model}\n`;
+                    logText += `Worlds: ${currentModel.getNumberWorlds()}\n`;
+                    logText += `Atomic Propositions: ${currentModel.getAtomicPropositions().size}\n`;
+                    logText += `Edges/Simulated: ${currentModel.getNumberEdges()} / ${currentModel.getNumberFalseEdges()}\n`;
+                    logText += `Pointed: ${currentModel.getPointedWorldID()}\n`;
+                    logText += '======= =======\n\n';
+                    console.log(logText);
 
                     if(SEPARATE_WORLDS_AGENTS) {
                         listModels.set(modelID, currentModel); 
+                        agentLog.write(logText);
                     }
 
                     return res.send({success: true, worlds: currentModel.worldNamesArray.length});
@@ -545,14 +589,17 @@ export class ApiRouter {
                 return {success: false};
             }
 
-            let modelID: String;
+            let agentLog : WriteStream;
+            let modelID : string;
             if(SEPARATE_WORLDS_AGENTS){
                 modelID = data.id;
+                agentLog = getAgentLogFile(modelID, logDir);
                 if(modelID === undefined){
                     console.log('No id for the world given');
                     return {success: false};
                 }
             }
+
 
             console.log('Creating model using ' + constraints.length + ' constraint formulas');
 
@@ -577,8 +624,8 @@ export class ApiRouter {
 
 
                 // Compress formula by substituting with simple proposition names
-                console.log("Constraints :");
-                console.log(cs);
+                // console.log("Constraints :");
+                // console.log(cs);
                 let origToNew = {};
                 let newToOrig = {};
 
@@ -618,27 +665,26 @@ export class ApiRouter {
                 // Create epistemic model from valuations
                 currentModel = parseModelFromValuations(fetchRes);
 
-                console.log("CURRENT MODEL :\n" + currentModel.toString())
                 // Create model parse end time
                 let modelParseEnd = Date.now();
 
-                console.log('');
-                console.log('Model Metrics:');
-                console.log('------- -------');
-                // console.log('Cached: ' + isCached);
-                console.log('Generation Time (ms): ' + (genEnd - start));
-                console.log('Model Creation Time (ms): ' + (modelParseEnd - genEnd));
-                console.log('Total Time (ms): ' + (modelParseEnd - start));
-                console.log('------- -------');
-                console.log('Constraints: ' + constraints.length);
-                console.log('Worlds: ' + currentModel.getNumberWorlds());
-                console.log('Atomic Propositions: ' + currentModel.getAtomicPropositions().size);
-                console.log('Edges/Simulated: ' + currentModel.getNumberEdges() + ' / ' + currentModel.getNumberFalseEdges());
-                console.log('Pointed: ' + currentModel.getPointedWorldID());
-                console.log('======= =======');
+
+                let logText = '';
+                logText += `CURRENT MODEL :\n${currentModel.toString()} \n`;
+                logText += 'Model Metrics:\n';
+                logText += '------- -------\n';
+                logText += `Total Time (ms): ${modelParseEnd - start}\n`;
+              //  logText += `Constraints: ${cs}\n`;
+                logText += `Worlds: ${currentModel.getNumberWorlds()}\n`;
+                logText += `Atomic Propositions: ${currentModel.getAtomicPropositions().size}\n`;
+                logText += `Edges/Simulated: ${currentModel.getNumberEdges()} / ${currentModel.getNumberFalseEdges()}\n`;
+                logText += `Pointed: ${currentModel.getPointedWorldID()}\n`;
+                logText += '======= =======\n\n';
+                console.log(logText);
 
                 if(SEPARATE_WORLDS_AGENTS) {
                     listModels.set(modelID, currentModel); 
+                    agentLog.write(logText);
                 }
 
                 return {success: true, worlds: currentModel.worldNamesArray.length};
@@ -664,9 +710,11 @@ export class ApiRouter {
         }
 
         app.post('/api/apply-event', async function(req, res) {
-            let modelID;
+            let agentLog : WriteStream;
+            let modelID : string;
             if(SEPARATE_WORLDS_AGENTS){
                 modelID = req.body.id;
+                agentLog = getAgentLogFile(modelID, logDir);
                 if(modelID === undefined){
                     console.log('No id for the world given');
                     return res.send({
@@ -684,6 +732,11 @@ export class ApiRouter {
                 let events = req.body.events || [];
                 console.log(events);
 
+                if(SEPARATE_WORLDS_AGENTS) {
+                    agentLog.write('\n***APPLY-EVENT*** \n\n');
+                }
+
+
                 if (events === 0) {
                     console.log('No events to apply.');
                     return res.send({success: false});
@@ -695,6 +748,10 @@ export class ApiRouter {
 
                 for (let ev of events) {
                     eventIds.push(ev.id);
+                    if(SEPARATE_WORLDS_AGENTS) {
+                        agentLog.write(`EVENT : ${ev.id} \n\n`);
+                    }
+    
                 }
 
                 let start = Date.now();
@@ -710,31 +767,36 @@ export class ApiRouter {
                 let result = eventModel.apply(currentModel);
                 let applyEvModEnd = Date.now();
 
-                console.log("RESULT : " + modelID + "\n" +  result);
+                currentModel = result;
+
+                let logText = '';
+                logText += `RESULT : ${modelID} \n${result} \n`
+                logText += 'Event Metrics:\n';
+                logText += '------- -------\n';
+                logText += `Event Creation (ms): ${createEvModEnd - start}\n`;
+                logText += `Event Application (ms): ${applyEvModEnd - createEvModEnd}\n`;
+                logText += `Total Time (ms): ${applyEvModEnd - start}\n`;
+                logText += '------- -------\n';
+                logText += `Events: ${eventIds.length}\n`;
+                logText += `Previous Worlds: ${prevWorlds}\n`;
+                logText += `Resulting Worlds: ${currentModel.getNumberWorlds()}\n`;
+                logText += `Edges/Simulated: ${currentModel.getNumberEdges()} / ${currentModel.getNumberFalseEdges()}\n`;
+                logText += '======= =======\n';
+                logText += '\n';
+
+
+                console.log(logText);
 
                 if (result === undefined) {
                     console.log('Failed to apply event');
                     return res.send({success: false});
                 }
 
-                currentModel = result;
                 if(SEPARATE_WORLDS_AGENTS) {
                     listModels.set(modelID, currentModel); 
+                    agentLog.write(logText);
                 }
 
-                console.log('');
-                console.log('Event Metrics:');
-                console.log('------- -------');
-                console.log('Event Creation (ms): ' + (createEvModEnd - start));
-                console.log('Event Application (ms): ' + (applyEvModEnd - createEvModEnd));
-                console.log('Total Time (ms): ' + (applyEvModEnd - start));
-                console.log('------- -------');
-                console.log('Events: ' + eventIds.length);
-                console.log('Previous Worlds: ' + prevWorlds);
-                console.log('Resulting Worlds: ' + currentModel.getNumberWorlds());
-                console.log('Edges/Simulated: ' + currentModel.getNumberEdges() + ' / ' + currentModel.getNumberFalseEdges());
-                console.log('======= =======');
-                console.log('');
 
                 let numOnEvents = 0;
 

--- a/src/app/ApiRouter.ts
+++ b/src/app/ApiRouter.ts
@@ -30,6 +30,8 @@ import {AgentEventModel} from './modules/core/models/eventmodel/agent-event-mode
 import Readlines from 'n-readlines';
 import * as process from 'process';
 
+let SEPARATE_WORLDS_AGENTS : Boolean;
+
 function createAcesAndEightsModel(): object {
     return {
         'initialModel': {
@@ -282,6 +284,7 @@ export class ApiRouter {
     createApp(app: express.Application, useCache: boolean = false): any {
 
         let currentModel: AgentExplicitEpistemicModel;
+        let listModels: Map<String,AgentExplicitEpistemicModel>;
 
         let createFake = true;
 
@@ -315,7 +318,6 @@ export class ApiRouter {
             console.log('Pointed: ' + val.getInitialEpistemicModel().getPointedWorldID());
 
         }
-        console.log('Hi');
 
         console.log(Object.keys(descCache).length + ' loaded into cache.');
 
@@ -344,7 +346,6 @@ export class ApiRouter {
             }
 
             resultObject.model = currentModel;
-
             res.send(resultObject);
             res.end();
         });
@@ -356,6 +357,16 @@ export class ApiRouter {
          * Output: { result: boolean }
          */
         app.post('/api/single-evaluate', async function(req, res) {
+            if(SEPARATE_WORLDS_AGENTS){
+                let modelID = req.body.id;
+                if(modelID === undefined){
+                    console.log('No id for the world given');
+                    return res.send({
+                        result: false
+                    });
+                }
+                currentModel = listModels.get(modelID);
+            }
             if (!currentModel) {
                 return res.send({result: false, error: 'No Environment.'});
             }
@@ -374,7 +385,6 @@ export class ApiRouter {
             let start = Date.now();
 
             let parsedForm = parseFormulaFromConstraint(formula);
-            console.log(parsedForm);
 
             // let parsedFormula = parseFormulaObject(formula);
 
@@ -398,6 +408,16 @@ export class ApiRouter {
          * Output: { result: boolean }
          */
         app.post('/api/evaluate', async function(req, res) {
+            if(SEPARATE_WORLDS_AGENTS){
+                let modelID = req.body.id;
+                if(modelID === undefined){
+                    console.log('No id for the world given');
+                    return res.send({
+                        result: false
+                    });
+                }
+                currentModel = listModels.get(modelID);
+            }
             if (!currentModel) {
                 return res.send({error: 'No Environment.'});
             }
@@ -419,6 +439,18 @@ export class ApiRouter {
 
                 console.log('No constraints given.');
                 return res.send({success: false});
+            }
+
+            SEPARATE_WORLDS_AGENTS = data.separateWorlds;
+            let modelID : String;
+            if(SEPARATE_WORLDS_AGENTS){
+                modelID = data.id;
+                if(modelID === undefined){
+                    console.log('No id for the world given');
+                    return res.send({
+                        result: false
+                    });
+                }
             }
 
             // Custom location map
@@ -470,6 +502,10 @@ export class ApiRouter {
                     console.log('Pointed: ' + currentModel.getPointedWorldID());
                     console.log('======= =======');
 
+                    if(SEPARATE_WORLDS_AGENTS) {
+                        listModels.set(modelID, currentModel); 
+                    }
+
                     return res.send({success: true, worlds: currentModel.worldNamesArray.length});
                 } catch (err) {
                     console.warn('An error occurred while parsing the input model. Error: ' + err);
@@ -493,18 +529,29 @@ export class ApiRouter {
                 //     constraints.push(JSON.parse(line));
                 // }
 
-                return res.send(await createModelFromConstraints(data.constraints, modelPath));
+                return res.send(await createModelFromConstraints(data, modelPath));
             }
 
 
-            return res.send(await createModelFromConstraints(data.constraints));
+            return res.send(await createModelFromConstraints(data));
         }
 
 
-        async function createModelFromConstraints(constraints, cachedModel: string = undefined) {
+        async function createModelFromConstraints(data, cachedModel: string = undefined) {
+
+            let constraints = data.constraints
             if (!constraints || constraints.length === 0) {
                 console.log('No constraints given.');
                 return {success: false};
+            }
+
+            let modelID: String;
+            if(SEPARATE_WORLDS_AGENTS){
+                modelID = data.id;
+                if(modelID === undefined){
+                    console.log('No id for the world given');
+                    return {success: false};
+                }
             }
 
             console.log('Creating model using ' + constraints.length + ' constraint formulas');
@@ -549,7 +596,7 @@ export class ApiRouter {
                 });
 
 
-                fetchRes = await TouistService.fetchModels(compressedForm.prettyPrint());
+                fetchRes = await TouistService.fetchModels(cs);
             }
             // Mark generation end time
             let genEnd = Date.now();
@@ -571,6 +618,7 @@ export class ApiRouter {
                 // Create epistemic model from valuations
                 currentModel = parseModelFromValuations(fetchRes);
 
+                console.log("CURRENT MODEL :\n" + currentModel.toString())
                 // Create model parse end time
                 let modelParseEnd = Date.now();
 
@@ -588,6 +636,10 @@ export class ApiRouter {
                 console.log('Edges/Simulated: ' + currentModel.getNumberEdges() + ' / ' + currentModel.getNumberFalseEdges());
                 console.log('Pointed: ' + currentModel.getPointedWorldID());
                 console.log('======= =======');
+
+                if(SEPARATE_WORLDS_AGENTS) {
+                    listModels.set(modelID, currentModel); 
+                }
 
                 return {success: true, worlds: currentModel.worldNamesArray.length};
 
@@ -612,16 +664,25 @@ export class ApiRouter {
         }
 
         app.post('/api/apply-event', async function(req, res) {
+            let modelID;
+            if(SEPARATE_WORLDS_AGENTS){
+                modelID = req.body.id;
+                if(modelID === undefined){
+                    console.log('No id for the world given');
+                    return res.send({
+                        result: false
+                    });
+                }
+                currentModel = listModels.get(modelID);
+            }
             if (!currentModel) {
                 console.log('No current model');
                 return res.end();
             }
 
-
-            console.log('apply-event called');
-
             try {
                 let events = req.body.events || [];
+                console.log(events);
 
                 if (events === 0) {
                     console.log('No events to apply.');
@@ -639,9 +700,9 @@ export class ApiRouter {
                 let start = Date.now();
 
                 if (eventIds.length > 5) {
-                    console.log('Received event model with ' + eventIds.length + ' events: ' + JSON.stringify(eventIds));
+                    console.log('Received event model with ' + eventIds.length + ' events: ' + JSON.stringify(eventIds) + '\n');
                 } else {
-                    console.log('Received event model with ' + eventIds.length + ' events');
+                    console.log('Received event model with ' + eventIds.length + ' events \n');
                 }
                 let eventModel = eventModelFromRequest(events);
                 let createEvModEnd = Date.now();
@@ -649,6 +710,7 @@ export class ApiRouter {
                 let result = eventModel.apply(currentModel);
                 let applyEvModEnd = Date.now();
 
+                console.log("RESULT : " + modelID + "\n" +  result);
 
                 if (result === undefined) {
                     console.log('Failed to apply event');
@@ -656,6 +718,9 @@ export class ApiRouter {
                 }
 
                 currentModel = result;
+                if(SEPARATE_WORLDS_AGENTS) {
+                    listModels.set(modelID, currentModel); 
+                }
 
                 console.log('');
                 console.log('Event Metrics:');
@@ -726,7 +791,7 @@ export class ApiRouter {
             }
 
             console.log(Object.keys(formulas).length + ' formulas took ' + (Date.now() - start) + ' or ' + formTot);
-
+     
             return formulaResults;
         }
 

--- a/src/app/ApiRouter.ts
+++ b/src/app/ApiRouter.ts
@@ -30,6 +30,7 @@ import {AgentEventModel} from './modules/core/models/eventmodel/agent-event-mode
 import Readlines from 'n-readlines';
 import * as process from 'process';
 import * as path from 'path';
+import { error } from 'console';
 
 
 
@@ -367,20 +368,33 @@ export class ApiRouter {
 
 
         app.get('/api/model', async function(req, res) {
+            let agentLog;
+            if (SEPARATE_WORLDS_AGENTS) {
+                // get the ID from the request parameters
+                let modelID = String(req.query.id);
+                agentLog = getAgentLogFile(modelID, logDir);
+        
+                if (modelID === undefined) {
+                    console.log('No id for the agent given');
+                    return res.send({
+                        result: new Error("No id for the agent given")
+                    });
+                }
+                currentModel = listModels.get(modelID);
+                agentLog.write(`GETTING MODEL FOR AGENT`);
+            }
+        
             if (!currentModel) {
-                return res.send({success: false, error: 'No Environment.'});
+                return res.send({ success: false, error: 'No Environment.' });
             }
-
+        
             let resultObject: any = {};
-
-            if (req.query && req.query.description) {
-                // resultObject.description = curEnvironment.getExampleDescription();
-            }
-
-            resultObject.model = currentModel;
-            res.send(resultObject);
-            res.end();
+        
+            resultObject.model = currentModel.worldArray;
+            res.json({ model: resultObject.model });
+            
         });
+
 
         /**
          * Evaluate a formula in the current state of the model.
@@ -393,13 +407,13 @@ export class ApiRouter {
             let agentLog : WriteStream;
             if(SEPARATE_WORLDS_AGENTS){
                 let modelID = req.body.id;
-                agentLog = getAgentLogFile(modelID, logDir);
                 if(modelID === undefined){
-                    console.log('No id for the world given');
+                    console.log('No id for the agent given');
                     return res.send({
                         result: false
                     });
                 }
+                agentLog = getAgentLogFile(modelID, logDir);
                 currentModel = listModels.get(modelID);
             }
             if (!currentModel) {
@@ -417,17 +431,12 @@ export class ApiRouter {
             }
 
 
-            let start = Date.now();
-
             let parsedForm = parseFormulaFromConstraint(formula);
 
-            // let parsedFormula = parseFormulaObject(formula);
-
-            let evalStart = Date.now();
             let result = currentModel.checkSync(parsedForm);
-            let delta = Date.now() - evalStart;
 
-            if(SEPARATE_WORLDS_AGENTS && result) {
+            // remove the && result here to see all the evaluations
+            if(SEPARATE_WORLDS_AGENTS) {
                 agentLog.write('\n\n*****SINGLE-EVALUATE***** \n\n');
                 agentLog.write(`FORMULA : ${parsedForm.prettyPrint()} --> ${result}  \n\n`);
             }
@@ -448,10 +457,12 @@ export class ApiRouter {
          * Output: { result: boolean }
          */
         app.post('/api/evaluate', async function(req, res) {
+            let agentLog : WriteStream;
             if(SEPARATE_WORLDS_AGENTS){
                 let modelID = req.body.id;
+                agentLog = getAgentLogFile(modelID, logDir);
                 if(modelID === undefined){
-                    console.log('No id for the world given');
+                    console.log('No id for the agent given');
                     return res.send({
                         result: false
                     });
@@ -459,16 +470,51 @@ export class ApiRouter {
                 currentModel = listModels.get(modelID);
             }
             if (!currentModel) {
-                return res.send({error: 'No Environment.'});
+                return res.send({result: false, error: 'No Environment.'});
             }
 
             let formulas = req.body.formulas || '';
-            // let currentModel = curEnvironment.getEpistemicModel();
 
-            let formulaResults = evaluateFormulas(formulas, currentModel);
+            let evalStart = Date.now();
 
+            let formulaTxt = "";
+
+            for (let formula of formulas){
+                let parsedForm = parseFormulaFromConstraint(formula);
+                formulaTxt += parsedForm.prettyPrint();
+            }
+
+            if(SEPARATE_WORLDS_AGENTS) {
+                agentLog.write('\n*****EVALUATE***** \n\n');
+                agentLog.write(`FORMULA : ${formulaTxt}`);
+            }
+            
+            for(let formula of formulas){
+                let parsedForm = parseFormulaFromConstraint(formula);
+                let result = currentModel.checkSync(parsedForm);
+                
+                // if you want to see the result foreach separated formula uncomment the lines down there
+                // if(SEPARATE_WORLDS_AGENTS) {
+                //     agentLog.write(`FORMULA : ${parsedForm.prettyPrint} --> ${result}  \n`);
+                // }
+
+                // If at least one proposition is false then the global one is false
+                if(!result){
+                    if(SEPARATE_WORLDS_AGENTS) {
+                        agentLog.write(` --> ${result} \n`);
+                    }
+                    return res.send({
+                        result: result
+                    });
+                }
+            }
+
+            console.log(formulaTxt);
+            if(SEPARATE_WORLDS_AGENTS) {
+                agentLog.write(' --> true \n');
+            }
             res.send({
-                result: formulaResults
+                result: true
             });
 
         });
@@ -491,7 +537,7 @@ export class ApiRouter {
                 agentLog = getAgentLogFile(modelID, logDir);
                 agentLog.write(`Agent ${modelID} started\n`);
                 if(modelID === undefined){
-                    console.log('No id for the world given');
+                    console.log('No id for the agent given');
                     return res.send({
                         result: false
                     });
@@ -573,11 +619,22 @@ export class ApiRouter {
                 //     constraints.push(JSON.parse(line));
                 // }
 
-                return res.send(await createModelFromConstraints(data, modelPath));
+                const result = await createModelFromConstraints(data, modelPath);
+
+                if (result.success) {
+                    return res.status(200).json(result);
+                } else {
+                    return res.status(500).json(result);
+                }
             }
 
+            const result = await createModelFromConstraints(data);
 
-            return res.send(await createModelFromConstraints(data));
+            if (result.success) {
+                return res.status(200).json(result);
+            } else {
+                return res.status(500).json(result);
+            }
         }
 
 
@@ -595,7 +652,7 @@ export class ApiRouter {
                 modelID = data.id;
                 agentLog = getAgentLogFile(modelID, logDir);
                 if(modelID === undefined){
-                    console.log('No id for the world given');
+                    console.log('No id for the agent given');
                     return {success: false};
                 }
             }
@@ -643,7 +700,12 @@ export class ApiRouter {
                 });
 
 
-                fetchRes = await TouistService.fetchModels(cs);
+                try {
+                    fetchRes = await TouistService.fetchModels(cs);
+                } catch (err) {
+                    console.error('[Touist Error] Failed to fetch models:', err.message);
+                    return { success: false, error: err.message };
+                }
             }
             // Mark generation end time
             let genEnd = Date.now();
@@ -667,7 +729,6 @@ export class ApiRouter {
 
                 // Create model parse end time
                 let modelParseEnd = Date.now();
-
 
                 let logText = '';
                 logText += `CURRENT MODEL :\n${currentModel.toString()} \n`;
@@ -700,13 +761,36 @@ export class ApiRouter {
         function eventModelFromRequest(events): AgentEventModel {
             let evModel = new AgentEventModel();
 
+            // here we want to remove the event that lead to nothing in case there are many events: for example +on(~obs(X)) : ~obs(X)
+
+            let size = events.length;
             for (let e of events) {
                 let {id, pre, post} = e;
+
+                // if we have more than 1 event and one of them is of the form +on(X) : X, we remove it (it doesn't give any information)
+                if(size > 1){
+                    let array = id.split(":");
+                    let content = extractContent(array[0]);
+                    if (array[1].trim().endsWith(".")) {
+                        array[1] = array[1].trim().slice(0, -1);
+                    }
+                    if (content === array[1]) {
+                        continue;
+                    }
+                }
 
                 evModel.addAction(id, parseFormulaFromConstraint(pre), parsePostFromRequest(post));
             }
 
             return evModel;
+        }
+
+        function extractContent(str: string): string {
+            str = str.trim();
+            if (str.startsWith("+on(") && str.endsWith(")")) {
+              return str.slice(4, -1);
+            }
+            return str;
         }
 
         app.post('/api/apply-event', async function(req, res) {
@@ -716,7 +800,7 @@ export class ApiRouter {
                 modelID = req.body.id;
                 agentLog = getAgentLogFile(modelID, logDir);
                 if(modelID === undefined){
-                    console.log('No id for the world given');
+                    console.log('No id for the agent given');
                     return res.send({
                         result: false
                     });
@@ -828,6 +912,68 @@ export class ApiRouter {
 
             res.end();
         });
+
+        app.post('/api/replace-props', async function(req, res) {
+            let agentLog : WriteStream;
+            let modelID : string;
+            // Consider this value always true
+            if(SEPARATE_WORLDS_AGENTS){
+                modelID = req.body.id;
+                agentLog = getAgentLogFile(modelID, logDir);
+                if(modelID === undefined){
+                    console.log('No id for the agent given');
+                    return res.send({
+                        result: false
+                    });
+                }
+                currentModel = listModels.get(modelID);
+                agentLog.write('\n***REPLACE-PROPS*** \n\n');
+            }
+
+            if (!currentModel) {
+                console.log('No current model');
+                return res.end();
+            }
+
+            try{
+                // Get the world and the new propositions
+                let worldAndNewProps = req.body.props || [];
+
+                if(worldAndNewProps === 0){
+                    console.log('No replacements to apply.');
+                    return res.send({success: false});
+                }
+
+                let start = Date.now();
+
+                let result = currentModel.applyReplacePropositions(worldAndNewProps);
+
+                let applyReplacementProps = Date.now();
+
+                currentModel = result;
+
+                let logText = '';
+                logText += `RESULT : ${modelID} \n`
+                logText += `${result} \n`
+
+                if (result === undefined) {
+                    console.log('Failed to replace props');
+                    return res.send({success: false});
+                }
+
+                if(SEPARATE_WORLDS_AGENTS) {
+                    listModels.set(modelID, currentModel); 
+                    agentLog.write(logText);
+                }
+
+                console.log('Total Time (ms): ' + (applyReplacementProps - start));
+                console.log('Memory check -- Breakpoint here? ' + (process.memoryUsage().heapUsed / 1000 / 1000));
+                return res.send({success: true});
+
+            } catch(error) {
+                console.error('There was an error updating the model: ' + error);
+            }
+        })
 
 
         function evaluateFormulas(formulas: any[] | any, model: AgentExplicitEpistemicModel): { [id: number]: boolean } {

--- a/src/app/ApiRouter.ts
+++ b/src/app/ApiRouter.ts
@@ -427,12 +427,12 @@ export class ApiRouter {
             let result = currentModel.checkSync(parsedForm);
             let delta = Date.now() - evalStart;
 
-            if(SEPARATE_WORLDS_AGENTS) {
-                agentLog.write('***SINGLE-EVALUATE*** \n');
-                agentLog.write(`FORMULA : ${parsedForm.prettyPrint()} --> ${result}  \n`);
+            if(SEPARATE_WORLDS_AGENTS && result) {
+                agentLog.write('\n\n*****SINGLE-EVALUATE***** \n\n');
+                agentLog.write(`FORMULA : ${parsedForm.prettyPrint()} --> ${result}  \n\n`);
             }
 
-            console.log('Single formula took ' + (Date.now() - start) + '(total), or eval time: ' + delta);
+          //  console.log('Single formula took ' + (Date.now() - start) + '(total), or eval time: ' + delta);
 
             return res.send({
                 result: result
@@ -746,12 +746,18 @@ export class ApiRouter {
 
                 let eventIds = [];
 
+                let logIt = true;
                 for (let ev of events) {
                     eventIds.push(ev.id);
-                    if(SEPARATE_WORLDS_AGENTS) {
-                        agentLog.write(`EVENT : ${ev.id} \n\n`);
+                    if(SEPARATE_WORLDS_AGENTS && logIt) {
+                        if (ev.id.startsWith("+on(moved(")){
+                            agentLog.write(`EVENT : ${ev.id.split(":")[0]} \n\n`);
+                            logIt = false;
+                        } else {
+                            agentLog.write(`EVENT : ${ev.id} \n\n`);
+                        }
                     }
-    
+
                 }
 
                 let start = Date.now();
@@ -770,7 +776,8 @@ export class ApiRouter {
                 currentModel = result;
 
                 let logText = '';
-                logText += `RESULT : ${modelID} \n${result} \n`
+                logText += `RESULT : ${modelID} \n`
+                logText += `${result} \n`
                 logText += 'Event Metrics:\n';
                 logText += '------- -------\n';
                 logText += `Event Creation (ms): ${createEvModEnd - start}\n`;
@@ -785,7 +792,7 @@ export class ApiRouter {
                 logText += '\n';
 
 
-                console.log(logText);
+              //  console.log(logText);
 
                 if (result === undefined) {
                     console.log('Failed to apply event');

--- a/src/app/ApiRouter.ts
+++ b/src/app/ApiRouter.ts
@@ -530,6 +530,7 @@ export class ApiRouter {
 
 
                 // Compress formula by substituting with simple proposition names
+                console.log("Constraints :");
                 console.log(cs);
                 let origToNew = {};
                 let newToOrig = {};
@@ -622,7 +623,7 @@ export class ApiRouter {
             try {
                 let events = req.body.events || [];
 
-                if (events === []) {
+                if (events === 0) {
                     console.log('No events to apply.');
                     return res.send({success: false});
                 }

--- a/src/app/ApiRouter.ts
+++ b/src/app/ApiRouter.ts
@@ -284,7 +284,7 @@ export class ApiRouter {
     createApp(app: express.Application, useCache: boolean = false): any {
 
         let currentModel: AgentExplicitEpistemicModel;
-        let listModels: Map<String,AgentExplicitEpistemicModel>;
+        let listModels: Map<String,AgentExplicitEpistemicModel> = new Map();
 
         let createFake = true;
 

--- a/src/app/modules/core/models/epistemicmodel/agent-explicit-epistemic-model.ts
+++ b/src/app/modules/core/models/epistemicmodel/agent-explicit-epistemic-model.ts
@@ -25,6 +25,17 @@ export class AgentExplicitEpistemicModel implements EpistemicModel {
     worldNamesSet: Set<string> = new Set<string>();
     worldNamesArray: Array<string> = new Array<string>();
 
+    toString(): String {
+        let s = '';
+
+        this.nodes.forEach((value, key) =>{
+            s += (key == "") ?  "Naan" : key;
+            s += " : " + value + "\n";
+        })
+
+        return s;
+    }
+
     getPointedWorld(): World {
         return this.getWorld(this.getPointedWorldID());
     }

--- a/src/app/modules/core/models/epistemicmodel/agent-explicit-epistemic-model.ts
+++ b/src/app/modules/core/models/epistemicmodel/agent-explicit-epistemic-model.ts
@@ -53,6 +53,23 @@ export class AgentExplicitEpistemicModel implements EpistemicModel {
      * Returns the true number of edges in the model
      */
     getNumberEdges(): Number {
+        // const numWorlds = this.getNumberWorlds();
+        // let numEdges = 0;
+    
+        // for (let world of this.worldArray) {
+        //     try {
+        //         const successorSet = this.getSuccessors(world, JasonAgentDescription.DEFAULT_AGENT);
+    
+        //         const numSuccessors = await successorSet.getNumber();
+    
+        //         numEdges += numSuccessors;
+    
+        //     } catch (error) {
+        //         console.error('Erreur lors de la récupération des successeurs pour le monde', world, error);
+        //     }
+        // }
+    
+        // return numEdges;
         return 0;
     }
 

--- a/src/app/modules/core/models/epistemicmodel/agent-explicit-epistemic-model.ts
+++ b/src/app/modules/core/models/epistemicmodel/agent-explicit-epistemic-model.ts
@@ -185,10 +185,6 @@ export class AgentExplicitEpistemicModel implements EpistemicModel {
                 return (c == 1);
             }
             case (phi instanceof types.NotFormula):
-                const basic_formula = (<types.NotFormula> phi).formula;
-                if(basic_formula instanceof types.AtomicFormula && basic_formula.getAtomicString().startsWith("obs(")){
-                    return false;
-                }
                 return !this.modelCheck(w, (<types.NotFormula> phi).formula);
             case (phi instanceof types.KFormula): {
                 let phi2 = <types.KFormula> phi;
@@ -326,4 +322,38 @@ export class AgentExplicitEpistemicModel implements EpistemicModel {
 
         return props;
     }
+
+    applyReplacePropositions(worldAndNewProps) : AgentExplicitEpistemicModel{
+
+        let ME = new AgentExplicitEpistemicModel();
+
+        for(let wp of worldAndNewProps){
+            const newProps = wp.newprops;
+            if(newProps == undefined){ throw new Error('newProps can\'t be undefined')}
+
+            //get the world that corresponds in the currentModel
+            //we double check that all worlds we modified are in the current model
+            const worldInModel = this.worldArray.find(w => w.equals(wp.world)) as WorldValuation;
+
+            if (!worldInModel) {
+                console.warn("Monde introuvable dans le modèle :", wp.world);
+                continue;
+            }
+
+            const newPropositionsToReplace: { [id: string]: boolean } = {};
+            for(let prop of newProps){
+                newPropositionsToReplace[prop.prop] = true;
+            }
+
+            ME.addWorld(this.nodeToID.get(worldInModel), new WorldValuation(new Valuation(newPropositionsToReplace)));
+        }
+
+        // Knowledge valuation has contradictions if there are no worlds (i.e. no pointed world was chosen).
+        if (ME.getNumberWorlds() === 0) {
+            console.warn('No resulting worlds.');
+        }
+
+        return ME;
+    }
+
 }

--- a/src/app/modules/core/models/epistemicmodel/agent-explicit-epistemic-model.ts
+++ b/src/app/modules/core/models/epistemicmodel/agent-explicit-epistemic-model.ts
@@ -185,6 +185,10 @@ export class AgentExplicitEpistemicModel implements EpistemicModel {
                 return (c == 1);
             }
             case (phi instanceof types.NotFormula):
+                const basic_formula = (<types.NotFormula> phi).formula;
+                if(basic_formula instanceof types.AtomicFormula && basic_formula.getAtomicString().startsWith("obs(")){
+                    return false;
+                }
                 return !this.modelCheck(w, (<types.NotFormula> phi).formula);
             case (phi instanceof types.KFormula): {
                 let phi2 = <types.KFormula> phi;

--- a/src/app/modules/core/models/epistemicmodel/explicit-doxastic-model.ts
+++ b/src/app/modules/core/models/epistemicmodel/explicit-doxastic-model.ts
@@ -310,7 +310,7 @@ export class ExplicitDoxasticModel extends Graph implements EpistemicModel {
                 }
             }
             case (phi instanceof types.BFormula): {
-                let phi2 = <types.KwFormula> phi;
+                let phi2 = <types.BFormula> phi;
                 let agent = phi2.agent;
                 let psi = phi2.formula;
                 return this.mostPlausible

--- a/src/app/modules/core/models/epistemicmodel/valuation.ts
+++ b/src/app/modules/core/models/epistemicmodel/valuation.ts
@@ -19,7 +19,14 @@ export class Valuation {
     }
 
     isPropositionTrue(p: string) {
-        return !!this.propositions[p];
+        let prop = p.split('/');
+        for(let pr of prop){
+            let res = !!this.propositions[pr];
+            if (!res){
+                return res;
+            }
+        }
+        return true;
     }
 
     /* the use of Maps is overkilling. Please use getPropositionMap */
@@ -64,5 +71,19 @@ export class Valuation {
         }
 
         return clone;
+    }
+
+    equals(other: Valuation): boolean {
+        const keysA = Object.keys(this.propositions);
+        const keysB = Object.keys(other.propositions);
+    
+        if (keysA.length !== keysB.length) return false;
+    
+        for (const key of keysA) {
+            if (!(key in other.propositions)) return false;
+            if (this.propositions[key] !== other.propositions[key]) return false;
+        }
+    
+        return true;
     }
 }

--- a/src/app/modules/core/models/epistemicmodel/world-valuation.ts
+++ b/src/app/modules/core/models/epistemicmodel/world-valuation.ts
@@ -11,4 +11,5 @@ export class WorldValuation extends World {
 
   modelCheck(p: string) { return this.valuation.isPropositionTrue(p); }
   toString() { return this.valuation.toString(); }
+  equals(otherWorld: WorldValuation) { return this.valuation.equals(otherWorld.valuation)}
 }

--- a/src/app/modules/core/models/epistemicmodel/world.ts
+++ b/src/app/modules/core/models/epistemicmodel/world.ts
@@ -11,4 +11,5 @@ export abstract class World {
    */
   abstract modelCheck(phi: string);
   abstract toString();
+  abstract equals(otherWorld: World);
 }

--- a/src/app/modules/core/services/touist.service.ts
+++ b/src/app/modules/core/services/touist.service.ts
@@ -152,7 +152,7 @@ export class TouistService {
         return true_props;
     }
 
-    static async fetchModels(reqStr: string, limit: number = 10000): Promise<string[][]> {
+    static async fetchModels(reqStr: string, limit: number = 1000000): Promise<string[][]> {
         let data = new FormData();
 
         let args = '--solve';
@@ -168,9 +168,11 @@ export class TouistService {
             body: data
         };
 
+        let responsetest = await fetch(`http://${SERVER_LOCATION}/`);
+
         let response = await fetch(`http://${SERVER_LOCATION}/touist_cmd`, methodInit);
         let text = await response.text();
-        let unescapedText = text.replace(/^"|"$/g, '').replace(/\\r\\n/g, '\r\n');
+        let unescapedText = JSON.parse(text);
 
         if (unescapedText.startsWith('unsat')) {
             return [];
@@ -178,7 +180,7 @@ export class TouistService {
 
         let res = [];
         let true_props = undefined;
-        for (let line of unescapedText.split('\r\n')) {
+        for (let line of unescapedText.split(/\r?\n/)) {
             if (line.startsWith('unsat')) {
                 break;
             }

--- a/src/app/modules/core/services/touist.service.ts
+++ b/src/app/modules/core/services/touist.service.ts
@@ -152,7 +152,7 @@ export class TouistService {
         return true_props;
     }
 
-    static async fetchModels(reqStr: string, limit: number = 10000000): Promise<string[][]> {
+    static async fetchModels(reqStr: string, limit: number = 10000): Promise<string[][]> {
         let data = new FormData();
 
         let args = '--solve';
@@ -170,7 +170,7 @@ export class TouistService {
 
         let response = await fetch(`http://${SERVER_LOCATION}/touist_cmd`, methodInit);
         let text = await response.text();
-        let unescapedText = text.replace(/\\r\\n/g, '\r\n');
+        let unescapedText = text.replace(/^"|"$/g, '').replace(/\\r\\n/g, '\r\n');
 
         if (unescapedText.startsWith('unsat')) {
             return [];

--- a/src/app/modules/core/services/touist.service.ts
+++ b/src/app/modules/core/services/touist.service.ts
@@ -155,20 +155,30 @@ export class TouistService {
     static async fetchModels(reqStr: string, limit: number = 1000000): Promise<string[][]> {
         let data = new FormData();
 
-        let args = '--solve';
-        args += ' --limit=' + limit;
+        let args = '--solve --limit=' + limit;
 
-        data.append('args', args);
-        data.append('stdin', reqStr);
-
-        // console.log(reqStr);
-
+        let payload = {
+            args: args,
+            stdin: reqStr
+        };
+    
         let methodInit = {
             method: 'POST',
-            body: data
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
         };
 
-        let responsetest = await fetch(`http://${SERVER_LOCATION}/`);
+        // data.append('args', args);
+        // data.append('stdin', reqStr);
+
+        // // console.log(reqStr);
+
+        // let methodInit = {
+        //     method: 'POST',
+        //     body: data
+        // };
 
         let response = await fetch(`http://${SERVER_LOCATION}/touist_cmd`, methodInit);
         let text = await response.text();

--- a/src/app/modules/core/services/touist.service.ts
+++ b/src/app/modules/core/services/touist.service.ts
@@ -137,19 +137,29 @@ export class TouistService {
             body: data
         };
 
-        let response = await fetch(`http://${SERVER_LOCATION}/touist_cmd`, methodInit);
-        let text = await response.text();
-        if (text.startsWith('unsat')) {
-            return [];
-        }
-        let true_props = [];
-        for (let line of text.split('\n')) {
-            let s = line.split(' ');
-            if (s[0] == '1') {
-                true_props.push(s[1]);
+        try {
+            let response = await fetch(`http://${SERVER_LOCATION}/touist_cmd`, methodInit);
+
+            if (!response.ok) {
+                throw new Error(`Touist server responded with status ${response.status}`);
             }
+
+            let text = await response.text();
+            if (text.startsWith('unsat')) {
+                return [];
+            }
+            let true_props = [];
+            for (let line of text.split('\n')) {
+                let s = line.split(' ');
+                if (s[0] == '1') {
+                    true_props.push(s[1]);
+                }
+            }
+            return true_props;
+        } catch (err) {
+            // Relayer l’erreur avec contexte
+            throw new Error(`Failed to fetch models from Touist server: ${err.message}`);
         }
-        return true_props;
     }
 
     static async fetchModels(reqStr: string, limit: number = 1000000): Promise<string[][]> {
@@ -170,53 +180,55 @@ export class TouistService {
             body: JSON.stringify(payload)
         };
 
-        // data.append('args', args);
-        // data.append('stdin', reqStr);
+        try {
+            let response = await fetch(`http://${SERVER_LOCATION}/touist_cmd`, methodInit);
 
-        // // console.log(reqStr);
+            let text = await response.text();
+            let unescapedText = JSON.parse(text);
 
-        // let methodInit = {
-        //     method: 'POST',
-        //     body: data
-        // };
-
-        let response = await fetch(`http://${SERVER_LOCATION}/touist_cmd`, methodInit);
-        let text = await response.text();
-        let unescapedText = JSON.parse(text);
-
-        if (unescapedText.startsWith('unsat')) {
-            return [];
-        }
-
-        let res = [];
-        let true_props = undefined;
-        for (let line of unescapedText.split(/\r?\n/)) {
-            if (line.startsWith('unsat')) {
-                break;
+            if (!response.ok) {
+                throw new Error(unescapedText.error);
             }
-            if (line.startsWith('==== model')) {
-                if (true_props !== undefined) {
-                    res.push(true_props);
+
+            let output = unescapedText.output;
+
+            if (output.startsWith('unsat')) {
+                return [];
+            }
+
+            let res = [];
+            let true_props = undefined;
+            for (let line of output.split(/\r?\n/)) {
+                if (line.startsWith('unsat')) {
+                    break;
                 }
-                true_props = [];
-                continue;
-            }
-            let s = line.split(' ');
-            if (s.length != 2) {
-                continue;
-            }
-            if (s[0] == '1') {
-                if (s[1].indexOf('\r') >= 0) {
-                    s[1] = s[1].replace('\r', '');
+                if (line.startsWith('==== model')) {
+                    if (true_props !== undefined) {
+                        res.push(true_props);
+                    }
+                    true_props = [];
+                    continue;
                 }
+                let s = line.split(' ');
+                if (s.length != 2) {
+                    continue;
+                }
+                if (s[0] == '1') {
+                    if (s[1].indexOf('\r') >= 0) {
+                        s[1] = s[1].replace('\r', '');
+                    }
 
-                true_props.push(s[1]);
+                    true_props.push(s[1]);
+                }
             }
+            if (true_props !== undefined) {
+                res.push(true_props);
+            }
+            return res;
+        } catch (err) {
+            // Relayer l’erreur avec contexte
+            throw new Error(`Failed to fetch models from Touist server: ${err.message}`);
         }
-        if (true_props !== undefined) {
-            res.push(true_props);
-        }
-        return res;
     }
 
     static async parse(text)

--- a/src/app/modules/core/services/touist.service.ts
+++ b/src/app/modules/core/services/touist.service.ts
@@ -170,13 +170,15 @@ export class TouistService {
 
         let response = await fetch(`http://${SERVER_LOCATION}/touist_cmd`, methodInit);
         let text = await response.text();
-        if (text.startsWith('unsat')) {
+        let unescapedText = text.replace(/\\r\\n/g, '\r\n');
+
+        if (unescapedText.startsWith('unsat')) {
             return [];
         }
 
         let res = [];
         let true_props = undefined;
-        for (let line of text.split('\n')) {
+        for (let line of unescapedText.split('\r\n')) {
             if (line.startsWith('unsat')) {
                 break;
             }


### PR DESCRIPTION
This PR adds several important features to the epistemic reasoner server:

### New Features

- **TouIST server integration**: added communication with the previously missing TouIST server (see repository: URL), enabling generation of all possible worlds for semantic models.
- **Parallel semantic model management**: now supports handling multiple semantic models in parallel, each associated with a specific agent name.

### Missing Repository & TouIST Server

Previously, the TouIST server required by the Jason epistemic extension was missing:
The server was originally hosted online as part of Vezina’s extension, but the public URL was no longer valid.
The original repository could not be found or retrieved.
As a result, the TouIST server has been **recreated**.
**This server is now required** for the Jason epistemic extension to function properly, as it is responsible for generating the possible worlds for semantic models.
The repository for this server is available at the following URL: https://github.com/Ethavanol/touist-service

### New API Endpoints

- **Retrieve** a semantic model.
- **Replace** a semantic model with a new one.

### Logging Improvements

**Automatic runtime log directory creation**:
- At each execution, a new folder is created with the current date and time.
- Inside, one log file per agent is stored, containing:
    - The created model with all possible worlds and their values.
    - The events applied to the model.
    - The epistemic evaluations performed on the model.
    - The retrieval of the model. 
    - The replacement of the model with a new one.